### PR TITLE
don't leave dir unchanged in case of error

### DIFF
--- a/lammps_interface/InputHandler.py
+++ b/lammps_interface/InputHandler.py
@@ -8,17 +8,18 @@ import subprocess
 
 
 def git_revision_hash():
+    wrk_dir = os.getcwd()
     try:
         src_dir = os.path.dirname(os.path.abspath(__file__))
-        wrk_dir = os.getcwd()
         os.chdir(src_dir)
         rev_no = len(subprocess.check_output(['git', 'rev-list', 'HEAD'], universal_newlines=True).strip().split("\n"))
         commit = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], universal_newlines=True).strip()
-        os.chdir(wrk_dir)
     except:
         # catchall in case the code is downloaded via a zip file
         rev_no = 1.0
         commit = "abcdefghijklmnop"
+    finally:
+        os.chdir(wrk_dir)
     return (rev_no, commit)
 rev_no, commit = git_revision_hash()
 __version_info__ = (0, 0, rev_no, "%s"%commit)


### PR DESCRIPTION
The except block will get triggered every time somebody installs this directly using pip, and that leaves the current directly in a dirty state, which breaks any code that assumes the cwd is in the current directory.

This fix just ensures that the current working dir is unchanged, regardless of what happens.

A good way of handling versions that avoids all this trouble (and works in all cases, including when the app is installed from a tarball) is to use python-versioneer: https://github.com/warner/python-versioneer.