### PR TITLE
prepare release on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,28 @@ information file (.[cif]) and the Large-scale Atomic Molecular Massively
 Parallel Simulator ([Lammps]).
 
 ## Installation
+Simply install from [PyPI](https://pypi.org/project/lammps-interface/):
 ```
-pip install -r requirements.txt
+pip install lammps-interface
 ```
-The Python module can be installed globally by:
+
+For development purposes, clone the repository and install it from source:
 ```
 pip install -e .
 ```
-Note: This adds `lammps-interface` to your `PATH`.
+
+Note: In both cases, this adds `lammps-interface` to your `PATH`.
 
 ## Usage
 
 ### Command line interface
 To see the optional arguments type:
 ```
-./lammps-interface --help
+lammps-interface --help
 ```
 To create [Lammps] simulation files for a given cif file type:
 ```
-./lammps-interface cif_file.cif
+lammps-interface cif_file.cif
 ```
 This will create [Lammps] simulation files with UFF parameters.
 

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,14 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setup(
-    name="lammps_interface",
-    version="0.1",
+    name="lammps-interface",
+    author="Peter Boyd, Mohamad Moosavi, Matthew Witman",
+    version="0.1.1",
+    license="MIT",
+    url="https://github.com/peteboyd/lammps_interface",
     description="Automatic generation of LAMMPS input files for molecular dynamics simulations of MOFs",
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     install_requires=requirements,
     include_package_data=True,
     packages=find_packages(),


### PR DESCRIPTION
This prepares the package for release on PyPI

I've already uploaded it on test.pypi.org for testing.

You can test installing it using
```
pip install --index-url https://test.pypi.org/simple/ lammps-interface
```
This is how the page will look like: https://test.pypi.org/project/lammps-interface/
Note: there will also be a link to your github

After this is merged, I will make the release and publish the package on PyPI.
If you would like me to make you a maintainer of the package there, register for an account on pypi.org and let me know your username.

P.S. In order to keep this knowledge around, I've created a [brief Wiki page on how to make a new release](https://github.com/peteboyd/lammps_interface/wiki/Releasing)