### PR TITLE
fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+build:
+  image: latest
+python:
+  version: 3.5
+  pip_install: true
+  extra_requirements:
+    - "docs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - python -V
 
 script:
-  - pip install -e .
+  - pip install -e .[docs]
   - lammps-interface --help
   - cd docs; make html
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -6,8 +6,9 @@ Build the documentation locally
 
 Build the documentation using::
 
+    pip install -e .[docs]  # install docs extra
     cd docs/
-    make html
+    make html  # build html documentation
     
 After building, find the documentation in ``docs/build/html/index.html``.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ scipy
 networkx
 # matplotlib 3.1 requires python 3.6
 matplotlib<3.1
-sphinx
-sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     install_requires=requirements,
+    extras_require={
+        'docs': [ 'sphinx>=2,<3', 'sphinx-rtd-theme>=0.4,<1' ]
+    },
     include_package_data=True,
     packages=find_packages(),
     scripts=['lammps-interface'],


### PR DESCRIPTION
Minor fixes to make the build on readthedocs work

 * add `.readthedocs.yaml` configuration file 
 * fix range of sphinx version (=the reason it was crashing)
 * move docs-only dependencies from `requirements.txt` to "extra"