### PR TITLE
add pypi publish workflow

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -1,0 +1,36 @@
+
+name: Publish on PyPI
+
+on:
+  push:
+    tags:
+      # After vMajor.Minor.Patch _anything_ is allowed (without "/") !
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'peteboyd/lammps_interface' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Upgrade setuptools and install package
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install -e .
+
+    - name: Build source distribution
+      run: python ./setup.py sdist
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
add github actions workflow for automatic pypi release (when pushing a
git tag of the form "v1.2.0"