### PR TITLE
fix unicode issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ MIT license (see [LICENSE](LICENSE))
 ## Citation
 The publication associated with this code is found here:
 
-Boyd, P. G., Moosavi, S. M., Witman, M. & Smit, B. Force-Field Prediction of Materials Properties in Metal-Organic Frameworks. J. Phys. Chem. Lett. 8, 357–363 (2017).
+Boyd, P. G., Moosavi, S. M., Witman, M. & Smit, B. Force-Field Prediction of Materials Properties in Metal-Organic Frameworks. J. Phys. Chem. Lett. 8, 357-363 (2017).
 
 https://dx.doi.org/10.1021/acs.jpclett.6b02532
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license="MIT",
     url="https://github.com/peteboyd/lammps_interface",
     description="Automatic generation of LAMMPS input files for molecular dynamics simulations of MOFs",
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     install_requires=requirements,
     extras_require={


### PR DESCRIPTION
The README contained a non-ASCII character.
Since the setup.py reads the README.md without specifying the encoding,
on systems where UTF-8 was not the default this could result in decoding
errors.

This commit both explicitly uses utf-8 to read the README and also
removes the (unnecessary) special character.